### PR TITLE
update dependences

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tantivy-stemmers"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 keywords = ["tantivy", "tokenizer", "stemmer"]
 categories = ["text-processing"]
@@ -50,13 +50,13 @@ yiddish_urieli = []
 
 [dependencies]
 aho-corasick = "1.1.3"
-precis-core = "0.1.9"
-precis-profiles = "0.1.10"
-serde = "1.0.199"
-serde_derive = "1.0.199"
-tantivy-tokenizer-api = "0.3.0"
-unicode-normalization = "0.1.23"
+precis-core = "0.1.11"
+precis-profiles = "0.1.13"
+serde = "1.0.228"
+serde_derive = "1.0.228"
+tantivy-tokenizer-api = "0.6.0"
+unicode-normalization = "0.1.24"
 
 [dev-dependencies]
-tantivy = "0.22.0"
+tantivy = "0.25.0"
 test_utils = { path = "./tests/utils" }

--- a/tests/utils/Cargo.toml
+++ b/tests/utils/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "test_utils"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 
 [dependencies]
-tantivy-tokenizer-api = "0.3.0"
+tantivy-tokenizer-api = "0.6.0"

--- a/tests/utils/src/lib.rs
+++ b/tests/utils/src/lib.rs
@@ -1,6 +1,6 @@
 use tantivy_tokenizer_api::BoxTokenStream;
 
-pub fn reduce_token_stream_to_string(token_stream: &mut BoxTokenStream) -> String {
+pub fn reduce_token_stream_to_string<'a>(token_stream: &mut BoxTokenStream<'a>) -> String {
     let mut tokens: Vec<String> = Vec::new();
 
     loop {


### PR DESCRIPTION
tatntivy 0.25 is not compatible with tantivy-tokenizer-api 0.3.0